### PR TITLE
await is not required

### DIFF
--- a/vendor/package/denovel/_database.ts
+++ b/vendor/package/denovel/_database.ts
@@ -10,9 +10,9 @@ import { connectMongo,connectPgsql,connectMysql } from "./drivers/index.ts";
 
 async function driver(Connection: string): Promise<any>{
     if(Connection === 'pgsql'){
-        return await connectPgsql(Postgres);
+        return connectPgsql(Postgres);
     }else if(Connection === 'mongod'){
-        return await connectMongo(Mongo);
+        return connectMongo(Mongo);
     }
 }
 


### PR DESCRIPTION
correct await dihapus dikarenakan sudah menggunakan return, untuk melanjutkan sebuah nilai, jadi tidak perlu lagi menggunakan await, kecuali seperti ini

const db = await connectMongo(Mongo);
return db;

baru boleh menggunakan await untuk melanjutkan sebuah nilai, jika tidak maka harus menggunakan promise menggunakan then.